### PR TITLE
Changing MINSEQE person_schema and root schema

### DIFF
--- a/minseqe/schema/investigation_schema.json
+++ b/minseqe/schema/investigation_schema.json
@@ -101,6 +101,5 @@
       "type": "string"
     }
   },
-  "additionalProperties": false,
-  "required":[]
+  "additionalProperties": false
 }

--- a/minseqe/schema/person_schema.json
+++ b/minseqe/schema/person_schema.json
@@ -69,5 +69,5 @@
     }
   },
   "additionalProperties": false,
-  "required":["lastName","firstName","email"]
+  "required":["lastName","firstName"]
 }

--- a/minseqe/schema/protocol_schema.json
+++ b/minseqe/schema/protocol_schema.json
@@ -56,5 +56,5 @@
     }
   },
   "additionalProperties": false,
-  "required":["name","type"]
+  "required":["name","protocol_type"]
 }


### PR DESCRIPTION
1. remove empty 'required' attribute in the root schema, otherwise won't work in Elixir validator
2. change compulsory 'email' in person_schema to optional. Many metadata doesn't include email information.
